### PR TITLE
Fix #30 by controlling the moment when the pop-ups are presented

### DIFF
--- a/smartPhone/src/app/app.component.ts
+++ b/smartPhone/src/app/app.component.ts
@@ -16,6 +16,7 @@ export class MyApp {
 
     activeNav: any;
     activePage: any;
+    backButtonAlertPresent: boolean;
 
     constructor(
         private storage: StorageProvider,
@@ -52,6 +53,8 @@ export class MyApp {
     }
 
     handleBackButtonAction() {
+        if(this.backButtonAlertPresent) return;
+
         this.activeNav = this.app.getActiveNav();
 
         if(this.activeNav.canGoBack()) {
@@ -65,6 +68,7 @@ export class MyApp {
                     if(firstUseDate == null) {
                         this.platform.exitApp();
                     } else {
+                        this.backButtonAlertPresent = true;
                         this.confirmBackButtonAction();
                     }
                 });
@@ -81,7 +85,7 @@ export class MyApp {
             message: 'Si continúas, el formulario no se enviará, pero se guardará para que lo edites más tarde.',
             buttons: [
                 {
-                    text: 'Salir',
+                    text: 'Sí',
                     handler: () => {
                         const tabIndex = this.activePage.data.formType === 'initial' ? 0 : 1;
                         this.app.getRootNav().setRoot(
@@ -92,11 +96,13 @@ export class MyApp {
                     }
                 },
                 {
-                    text: 'Cancelar',
+                    text: 'No',
                     role: 'cancel'
                 }
             ]
         });
+
         alert.present();
+        alert.onDidDismiss(() => { this.backButtonAlertPresent = false; });
     }
 }

--- a/smartPhone/src/pages/form/form.ts
+++ b/smartPhone/src/pages/form/form.ts
@@ -374,6 +374,11 @@ export class FormPage {
     }
 
     async finalizarEncuesta() {
+        this.loader = this.loadingController.create({
+            content: 'Espere...',
+        });
+        this.loader.present();
+
         const array = Array.from(document.querySelectorAll('ion-datetime, ion-input, ion-list, ion-item'));
         const elementos = [];
         let errores = 0;
@@ -394,6 +399,8 @@ export class FormPage {
         if (errores == 0) {
             await this.storage.set('formSent', true);
             this.enviarFormulario();
+        } else {
+            this.loader.dismiss();
         }
     }
 
@@ -471,6 +478,7 @@ export class FormPage {
             this.subirArchivo(pendingForm, id_dataset);
         } else {
             this.app.getRootNav().setRoot(TabsPage);
+            this.loader.dismiss();
             const alert = this.alertCtrl.create({
                 subTitle: 'No se encontraron cambios a registrar.',
                 buttons: ['cerrar']
@@ -480,11 +488,6 @@ export class FormPage {
     }
 
     subirArchivo(pendingForm: any, id_dataset: string) {
-        this.loader = this.loadingController.create({
-            content: 'Espere...',
-        });
-        this.loader.present();
-
         let fileName = 'AUTODIAGNÓSTICO';
         if(pendingForm.formData.type === 'initial') {
             fileName = 'DATOS-PERSONALES';


### PR DESCRIPTION
- Back button alert in forms is presented only if there is no alert being presented yet
- Loader 'Espere...'  when sending forms is presented right after clicking 'Finalizar', at the very beginning of the handler

Signed-off-by: Xavier Figueroa <xavierfigueroav@gmail.com>